### PR TITLE
Added a HELPDESK on the side bar containing the page for the ticketing system + Corrected a few other stuff elsewhere

### DIFF
--- a/docs/sd/sd001.md
+++ b/docs/sd/sd001.md
@@ -18,6 +18,8 @@ import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 
+:::note The ticketing system is not live yet, please check in the Telegram main chat if we are already using for the registration of every stuck transaction!  Beware of scammers that may already try to redirect you to a look-a-like website, the only legit url for the ticketing portal is https://0exchange.atlassian.net/servicedesk/customer/portals + never ever connect your wallet or give your seed phrase if a fake website asks to do so! :::
+
 ## Registration in the ticketing system of a stuck transaction after a cross chain
 
 :::warning

--- a/docs/sd/sd001.md
+++ b/docs/sd/sd001.md
@@ -44,7 +44,7 @@ Please read the information below regarding how it will resolved and when, what 
 * In 99.99999% of the cases, you will receive the tokens on the destination chain as intended.  For a few exceptional cases, the funds were returned to the origin chain
 * __Follow-up:__ We will not inform you by mail or with a personal message to your Telegram handle when the transaction has been solved.
   * You will find out by yourself that the issue has been resolved (funds are in your wallet)
-  * If after 24h (or on a Monday (working day - US time zone) if the ticket has been registered between Friday and Sunday), the issue has still not been solved, [join the main chat on Telegram](https://t.me/ZeroExchangeCommunity) and ask for an admin to take a look at your case 
+  * If after 24h (or on a Monday, US time zone, if the ticket has been registered between Friday and Sunday), the issue has still not been solved, [join the main chat on Telegram](https://t.me/ZeroExchangeCommunity) and ask for an admin to take a look at your case 
   * If you entered a valid email address, you may receive a mail at some point that the issue is closed.  Closing is done automatically after a few days (unless you contacted us again to inform that the issue is still open)
   * If you need communication about your issue, [join the main chat on Telegram](https://t.me/ZeroExchangeCommunity).  For the time being, we won't exchange via mail/comments on the registered ticket. 
 

--- a/docs/sd/sd001.md
+++ b/docs/sd/sd001.md
@@ -54,7 +54,7 @@ Please read the information below regarding how it will resolved and when, what 
 Some cases of waiting occasionally up to an hour have been reported if the origin or destination chains are suffering temporary lags due to technical issues unrelated to the bridge of the exchange (typically affects more BSC and Polygon once in a while than the other chains, they can be sometimes congested).
 * Have you checked that when you switch to the destination chain on the Zero Exchange interface, the cross-chained tokens appears on the Zero Exchange interface on the swap page? (even if you have not added the token address in MetaMask, they should appear there once they have successfully been transferred from one chain to the other)  
 <img alt="Select liquidity pool" src={useBaseUrl('/img/sd001-001.png')} />
-* Don't confuse a stuck transaction with a failed transfer initiation on the origin network: Did you have enough tokens for the gas fees or did you use the correct gas settings in MetaMask (especially when Ethereum is the origin chain)
+* Don't confuse a stuck transaction with a failed transfer initiation on the origin network: Did you have enough tokens for the gas fees or did you use the correct gas settings in MetaMask (especially when Ethereum is the origin chain)?
   * [Community content on some good practice with MetaMask prior to cross-chain transfers](https://0.masternode.io/docs/eth#cross-chain-transfers)
   * [Official Zero exchange documentation about the gas settings](https://0-exchange.gitbook.io/0-exchange-docs/pinned/transaction-fails) 
 

--- a/docs/sd/sd001.md
+++ b/docs/sd/sd001.md
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 
-:::note The ticketing system is not live yet, please check in the Telegram main chat if we are already using for the registration of every stuck transaction!  Beware of scammers that may already try to redirect you to a look-a-like website, the only legit url for the ticketing portal is https://0exchange.atlassian.net/servicedesk/customer/portals + never ever connect your wallet or give your seed phrase if a fake website asks to do so! :::
+:::note The ticketing system is not live yet, please check in the Telegram main chat if we are already using it for the systematic registration of every stuck transaction!  Beware of scammers that may already try to redirect you to a look-a-like website, the only legit url for the ticketing portal is https://0exchange.atlassian.net/servicedesk/customer/portals + never ever connect your wallet or give your seed phrase if a fake website asks to do so! :::
 
 ## Registration in the ticketing system of a stuck transaction after a cross chain
 

--- a/docs/whatiszeroexchange.md
+++ b/docs/whatiszeroexchange.md
@@ -81,7 +81,7 @@ The Zero Exchange is at its core a multi and cross chain decentralized exchange.
 
 Exchange was launched at the end of January 2021.
 
-### Token presale or investors
+#### Token presale or investors
 No presale, no investors. The team invested 60 ETH of their own to bootstrap the project.
 
 #### Some achievements of the project since going live

--- a/sidebars.js
+++ b/sidebars.js
@@ -3,6 +3,7 @@ module.exports = {
     GUIDES: ['whatiszeroexchange','howtobuyzero','zerobridge','zerogravity','fructifyzero','roadmap','partnerships','defiacademy','faq', 'communities','mobile','eth','avax','bsc','polygon'],	  
 	FAQ: ['faq/faq001','faq/faq002','faq/faq003','faq/faq004','faq/faq005','faq/faq006','faq/faq007','faq/faq008','faq/faq009','faq/faq010','faq/faq011','faq/faq012','faq/faq013','faq/faq014','faq/faq015','faq/faq016','faq/faq017','faq/faq018','faq/faq019','faq/faq020','faq/faq021','faq/faq022','faq/faq023','faq/faq024','faq/faq025','faq/faq026','faq/faq027'],
 	IDO: ['ido/ido001','ido/ido002','ido/ido003','ido/ido004','ido/ido005'],
+	HELPDESK: ['sd/sd001'],  
 	EXPLAINERS: ['il','nft','rugpull'],
 	FUTURE: ['sol','grow','apes'],
   },


### PR DESCRIPTION
There is a note in sd001.md saying that the system is not live yet.  I will do a test run with some regulars who have a number of stuck tx after their name.   But I can already communicate that page to others so that they read about the process/timing/get the tx ID., while they still communicate their TX ID in TG